### PR TITLE
Add `lastUpdated` field when adding data to database

### DIFF
--- a/db/db.py
+++ b/db/db.py
@@ -32,7 +32,10 @@ def add_order_to_customer(transaction, email, ticket_ref):
             "lastUpdated": SERVER_TIMESTAMP
         })
     else:
-        transaction.update(query[0].reference, {"ticketIds": firestore.ArrayUnion([ticket_ref.id])})
+        transaction.update(query[0].reference, {
+            "ticketIds": firestore.ArrayUnion([ticket_ref.id]),
+            "lastUpdated": SERVER_TIMESTAMP
+        })
 
 def add_orders(orders):
     # Assumption: the cat_dict keys are catA, catB, catC following the naming in firestore


### PR DESCRIPTION
This pull request introduces a new feature to track the last updated timestamp for orders and tickets in the Firestore database. The most important changes include importing the `SERVER_TIMESTAMP` constant and adding it to relevant Firestore document updates.

### Firestore timestamp tracking:

* [`db/db.py`](diffhunk://#diff-dcafedb179a0e871804d8207fcf35249ddce9e35aa75ba5697c3008e64a7c174R7): Imported `SERVER_TIMESTAMP` from `google.cloud.firestore` to enable automatic timestamp management for Firestore documents.
* `db/db.py` (`add_order_to_customer`): Added the `lastUpdated` field with the value `SERVER_TIMESTAMP` when creating or updating customer orders.
* `db/db.py` (`add_orders`): Added the `lastUpdated` field with the value `SERVER_TIMESTAMP` when creating new ticket documents.

### Related Issues:
* Resolve #24 